### PR TITLE
Fix mountDir scoping error in DMG installation

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -650,8 +650,8 @@ const installSelected = async (selected, downloadPath, log, yesFlag = false) => 
     case "dmg":
       installationMethod = "dmg";
 
+      const mountDir = path.join(tmpdir, "dmg-mount");
       try {
-        const mountDir = path.join(tmpdir, "dmg-mount");
         fs.mkdirSync(mountDir, { recursive: true });
         mountDMG(downloadPath, mountDir, log);
         let dmgBinaries = getBinaries(mountDir);


### PR DESCRIPTION
## Summary
- Fixed `ReferenceError: mountDir is not defined` when installing DMG files
- Moved `mountDir` declaration outside try block to make it accessible in finally block

## Test plan
- [ ] Test DMG file installation to ensure no mountDir error occurs
- [ ] Verify DMG mounting and unmounting still works correctly
- [ ] Test both successful and failed DMG installations to ensure cleanup works

🤖 Generated with [Claude Code](https://claude.com/claude-code)